### PR TITLE
[TS-12] Update example KB-JWT

### DIFF
--- a/docs/technical-specifications/ts12-electronic-payments-SCA-implementation-with-wallet.md
+++ b/docs/technical-specifications/ts12-electronic-payments-SCA-implementation-with-wallet.md
@@ -468,6 +468,7 @@ The following is a non-normative example of the KB-JWT object:
     "jti": "deeec2b0-3bea-4477-bd5d-e3462a709481",
     "nonce": "bUtJdjJESWdmTWNjb011YQ",
     "sd_hash": "Re-CtLZfjGLErKy3eSriZ4bBx3AtUH5Q5wsWiiWKIwY",
+    "response_mode": "direct_post",
     "amr": [
         {"knowledge": "passphrase_less_than_8_chars"},
         {"inherence": "fingerprint_device"}


### PR DESCRIPTION
Added required `response_mode` claim to non-normative KB-JWT example response in TS-12.

----

Going through TS-12, I noticed that one of the required claims of the [response KB-JWT](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts12-electronic-payments-SCA-implementation-with-wallet.md#36-presentation-response) is the `response_mode` claim. However, in the (non-normative) example, this claim is missing.

Is there a reason for leaving the `response_mode` claim out of the example, or was it accidentally left out? If this is the case, I've added it to the example, see the commit.