### PR TITLE
Fix typo in key attestation type format

### DIFF
--- a/docs/technical-specifications/ts3-wallet-unit-attestation.md
+++ b/docs/technical-specifications/ts3-wallet-unit-attestation.md
@@ -448,7 +448,7 @@ Example of a `key_attestation` object:
 
 ```
 {
-  "typ": "keyattestation+jwt",
+  "typ": "key-attestation+jwt",
   "alg": "ES256",
   "x5c": ["MIIDQjCCA..."]
 }


### PR DESCRIPTION
fix typo mentioned in issue #605 after verifying from reference: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-application-key-attestation